### PR TITLE
Add admin product lines and password management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ Sistema simples em PHP para controle de usuários.
 
 ## Funcionalidades
 - Registro e login de usuários
-- Tema claro/escuro com opção de alternar
+- Tema claro/escuro com opção de alternar (botão com ícones de sol e lua)
 - Menu lateral após login
 - Usuários administradores podem gerenciar níveis de outros usuários
+- Tela para trocar senha
+- Registro da data/hora do último login (visível em Usuários)
+- Menu Admin com gerenciamento de Linhas de Produto
 - Todas as ações geram logs em `storage/app.log`
 
 Configure o acesso ao banco de dados em `conf.env`.

--- a/public/change_password.php
+++ b/public/change_password.php
@@ -1,0 +1,56 @@
+<?php
+require_once __DIR__ . '/../src/Auth.php';
+Auth::start();
+User::init();
+
+$user = Auth::user();
+if (!$user) {
+    header('Location: index.php');
+    exit;
+}
+
+$dark = isset($_COOKIE['dark']) ? 'dark' : '';
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $ok = User::changePassword($user['id'], $_POST['old_password'], $_POST['new_password']);
+    if ($ok) {
+        Logger::info($user['username'], 'change_password', 'Password changed');
+        $message = 'Senha alterada.';
+    } else {
+        $message = 'Senha atual incorreta.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>Trocar Senha</title>
+</head>
+<body class="<?php echo $dark; ?>">
+<div class="layout">
+    <nav class="menu">
+        <ul>
+            <li><a href="index.php">Início</a></li>
+            <li><a href="change_password.php"><strong>Trocar Senha</strong></a></li>
+        </ul>
+        <div class="bottom">
+            <button onclick="location.href='index.php?logout=1'">Logout</button>
+            <button id="dark-toggle" class="toggle"><span class="sun">☀</span><span class="moon">🌙</span><span class="knob"></span></button>
+        </div>
+    </nav>
+    <main class="content">
+        <h1>Trocar Senha</h1>
+        <?php if ($message) echo '<p>' . htmlspecialchars($message) . '</p>'; ?>
+        <form method="post">
+            <label>Senha Atual:<br><input type="password" name="old_password" required></label><br>
+            <label>Nova Senha:<br><input type="password" name="new_password" required></label><br>
+            <button type="submit">Salvar</button>
+        </form>
+    </main>
+</div>
+<script src="toggle.js"></script>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -46,12 +46,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$user) {
         <ul>
             <li><a href="index.php">Início</a></li>
             <?php if ($user['type'] === 'Admin'): ?>
-            <li><a href="users.php">Usuários</a></li>
+            <li>Admin
+                <ul>
+                    <li><a href="users.php">Usuários</a></li>
+                    <li><a href="product_lines.php">Linhas de Produto</a></li>
+                </ul>
+            </li>
             <?php endif; ?>
+            <li><a href="change_password.php">Trocar Senha</a></li>
         </ul>
         <div class="bottom">
             <button onclick="location.href='?logout=1'">Logout</button>
-            <button id="dark-toggle">Darkmode</button>
+            <button id="dark-toggle" class="toggle">
+                <span class="sun">☀</span>
+                <span class="moon">🌙</span>
+                <span class="knob"></span>
+            </button>
         </div>
     </nav>
     <main class="content">

--- a/public/product_lines.php
+++ b/public/product_lines.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../src/Auth.php';
+require_once __DIR__ . '/../src/ProductLine.php';
+Auth::start();
+User::init();
+ProductLine::init();
+
+$user = Auth::user();
+if (!$user || $user['type'] !== 'Admin') {
+    header('Location: index.php');
+    exit;
+}
+
+$dark = isset($_COOKIE['dark']) ? 'dark' : '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['id'])) {
+        ProductLine::update((int)$_POST['id'], $_POST['name'], $_POST['description']);
+        Logger::info($user['username'], 'update_product_line', 'Updated line ' . $_POST['id']);
+    } else {
+        ProductLine::create($_POST['name'], $_POST['description']);
+        Logger::info($user['username'], 'create_product_line', 'Created product line');
+    }
+    header('Location: product_lines.php');
+    exit;
+}
+
+$lines = ProductLine::all();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="style.css">
+<title>Linhas de Produto</title>
+</head>
+<body class="<?php echo $dark; ?>">
+<div class="layout">
+    <nav class="menu">
+        <ul>
+            <li><a href="index.php">Início</a></li>
+            <li>Admin
+                <ul>
+                    <li><a href="users.php">Usuários</a></li>
+                    <li><a href="product_lines.php"><strong>Linhas de Produto</strong></a></li>
+                </ul>
+            </li>
+        </ul>
+        <div class="bottom">
+            <button onclick="location.href='index.php?logout=1'">Logout</button>
+            <button id="dark-toggle" class="toggle"><span class="sun">☀</span><span class="moon">🌙</span><span class="knob"></span></button>
+        </div>
+    </nav>
+    <main class="content">
+        <h1>Linhas de Produto</h1>
+        <h2>Nova Linha</h2>
+        <form method="post">
+            <label>Nome:<br><input type="text" name="name" required></label><br>
+            <label>Descrição:<br><textarea name="description" rows="3" cols="40" required></textarea></label><br>
+            <button type="submit">Adicionar</button>
+        </form>
+        <h2>Existentes</h2>
+        <table>
+            <tr><th>Nome</th><th>Descrição</th><th>Ação</th></tr>
+            <?php foreach ($lines as $l): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($l['name']); ?></td>
+                <td><?php echo htmlspecialchars($l['description']); ?></td>
+                <td>
+                    <form method="post" style="display:inline;">
+                        <input type="hidden" name="id" value="<?php echo $l['id']; ?>">
+                        <input type="text" name="name" value="<?php echo htmlspecialchars($l['name']); ?>" required>
+                        <textarea name="description" rows="2" cols="20" required><?php echo htmlspecialchars($l['description']); ?></textarea>
+                        <button type="submit">Salvar</button>
+                    </form>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </table>
+    </main>
+</div>
+<script src="toggle.js"></script>
+</body>
+</html>

--- a/public/readme.php
+++ b/public/readme.php
@@ -19,16 +19,7 @@ Logger::info($user['username'] ?? 'guest', 'readme', 'Viewed README');
 <h1>README</h1>
 <pre><?php echo htmlspecialchars($readme); ?></pre>
 <p><a href="index.php">Back</a></p>
-<p><a href="?dark=toggle">Toggle dark mode</a></p>
-<?php
-if (isset($_GET['dark']) && $_GET['dark'] === 'toggle') {
-    if (isset($_COOKIE['dark'])) {
-        setcookie('dark', '', time()-3600);
-    } else {
-        setcookie('dark', '1', time()+3600*24*30);
-    }
-    header('Location: readme.php');
-}
-?>
+<button id="dark-toggle" class="toggle"><span class="sun">☀</span><span class="moon">🌙</span><span class="knob"></span></button>
+<script src="toggle.js"></script>
 </body>
 </html>

--- a/public/register.php
+++ b/public/register.php
@@ -31,6 +31,7 @@ $dark = isset($_COOKIE['dark']) ? 'dark' : '';
 <button type="submit">Register</button>
 </form>
 <p><a href="index.php">Login</a></p>
+<button id="dark-toggle" class="toggle"><span class="sun">☀</span><span class="moon">🌙</span><span class="knob"></span></button>
 <script src="toggle.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -34,8 +34,40 @@ body.dark .login-container {
 body.dark .menu { background: #222; }
 .menu ul { list-style: none; padding: 0; flex-grow: 1; }
 .menu ul li { margin-bottom: 1em; }
+.menu ul ul { padding-left: 1em; }
 .menu .bottom { margin-top: auto; }
 .content { flex-grow: 1; padding: 20px; }
+
+.toggle {
+    position: relative;
+    width: 50px;
+    height: 24px;
+    background: #ccc;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+}
+.toggle .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    background: #fff;
+    border-radius: 50%;
+    transition: left 0.3s;
+}
+.toggle .sun,
+.toggle .moon {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 12px;
+}
+.toggle .sun { left: 6px; }
+.toggle .moon { right: 6px; }
+body.dark .toggle { background: #666; }
+body.dark .toggle .knob { left: 28px; background: #222; }
 
 table { border-collapse: collapse; width: 100%; }
 td, th { border: 1px solid #ccc; padding: 0.5em; }

--- a/public/users.php
+++ b/public/users.php
@@ -34,21 +34,28 @@ $dark = isset($_COOKIE['dark']) ? 'dark' : '';
     <nav class="menu">
         <ul>
             <li><a href="index.php">Início</a></li>
-            <li><strong>Usuários</strong></li>
+            <li>Admin
+                <ul>
+                    <li><strong>Usuários</strong></li>
+                    <li><a href="product_lines.php">Linhas de Produto</a></li>
+                </ul>
+            </li>
+            <li><a href="change_password.php">Trocar Senha</a></li>
         </ul>
         <div class="bottom">
             <button onclick="location.href='index.php?logout=1'">Logout</button>
-            <button id="dark-toggle">Darkmode</button>
+            <button id="dark-toggle" class="toggle"><span class="sun">☀</span><span class="moon">🌙</span><span class="knob"></span></button>
         </div>
     </nav>
     <main class="content">
         <h1>Usuários</h1>
         <table>
-            <tr><th>Nome</th><th>Tipo</th><th>Ação</th></tr>
+            <tr><th>Nome</th><th>Tipo</th><th>Último Login</th><th>Ação</th></tr>
             <?php foreach ($users as $u): ?>
             <tr>
                 <td><?php echo htmlspecialchars($u['username']); ?></td>
                 <td><?php echo htmlspecialchars($u['type']); ?></td>
+                <td><?php echo htmlspecialchars($u['last_login'] ? date('Y-m-d H:i', strtotime($u['last_login'])) : ''); ?></td>
                 <td>
                     <form method="post" style="display:inline;">
                         <input type="hidden" name="id" value="<?php echo $u['id']; ?>">

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -22,6 +22,7 @@ class Auth {
                 'username' => $user['username'],
                 'type' => $user['type']
             ];
+            User::recordLogin($user['id']);
             Logger::info($user['username'], 'login', 'User logged in');
             return true;
         }

--- a/src/ProductLine.php
+++ b/src/ProductLine.php
@@ -1,0 +1,42 @@
+<?php
+require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/Logger.php';
+
+class ProductLine {
+    public static function init() {
+        $db = Database::getConnection();
+        $stmt = sqlsrv_query($db, "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'product_lines'");
+        $row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_NUMERIC);
+        if ($row[0] == 0) {
+            $sql = "CREATE TABLE product_lines (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(255),
+                description NVARCHAR(MAX)
+            )";
+            sqlsrv_query($db, $sql);
+        }
+    }
+
+    public static function all() {
+        $db = Database::getConnection();
+        $stmt = sqlsrv_query($db, 'SELECT * FROM product_lines');
+        $lines = [];
+        while ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
+            $lines[] = $row;
+        }
+        return $lines;
+    }
+
+    public static function create($name, $desc) {
+        $db = Database::getConnection();
+        $stmt = sqlsrv_query($db, 'INSERT INTO product_lines (name, description) VALUES (?, ?)', [$name, $desc]);
+        return $stmt !== false;
+    }
+
+    public static function update($id, $name, $desc) {
+        $db = Database::getConnection();
+        $stmt = sqlsrv_query($db, 'UPDATE product_lines SET name = ?, description = ? WHERE id = ?', [$name, $desc, $id]);
+        return $stmt !== false;
+    }
+}
+?>

--- a/src/User.php
+++ b/src/User.php
@@ -17,9 +17,16 @@ class User {
                 id INT IDENTITY(1,1) PRIMARY KEY,
                 username NVARCHAR(255) UNIQUE,
                 password NVARCHAR(255),
-                type NVARCHAR(50)
+                type NVARCHAR(50),
+                last_login DATETIME NULL
             )";
             sqlsrv_query($db, $sql);
+        }
+
+        $stmt = sqlsrv_query($db, "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'users' AND COLUMN_NAME = 'last_login'");
+        $row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_NUMERIC);
+        if ($row[0] == 0) {
+            sqlsrv_query($db, 'ALTER TABLE users ADD last_login DATETIME NULL');
         }
 
         // Create admin if not exists
@@ -52,7 +59,7 @@ class User {
 
     public static function all() {
         $db = Database::getConnection();
-        $stmt = sqlsrv_query($db, 'SELECT id, username, type FROM users');
+        $stmt = sqlsrv_query($db, 'SELECT id, username, type, last_login FROM users');
         $users = [];
         while ($row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC)) {
             $users[] = $row;
@@ -63,6 +70,23 @@ class User {
     public static function updateType($id, $type) {
         $db = Database::getConnection();
         $stmt = sqlsrv_query($db, 'UPDATE users SET type = ? WHERE id = ?', [$type, $id]);
+        return $stmt !== false;
+    }
+
+    public static function recordLogin($id) {
+        $db = Database::getConnection();
+        sqlsrv_query($db, 'UPDATE users SET last_login = GETDATE() WHERE id = ?', [$id]);
+    }
+
+    public static function changePassword($id, $old, $new) {
+        $db = Database::getConnection();
+        $stmt = sqlsrv_query($db, 'SELECT password FROM users WHERE id = ?', [$id]);
+        $row = sqlsrv_fetch_array($stmt, SQLSRV_FETCH_ASSOC);
+        if (!$row || !password_verify($old, $row['password'])) {
+            return false;
+        }
+        $hash = password_hash($new, PASSWORD_DEFAULT);
+        $stmt = sqlsrv_query($db, 'UPDATE users SET password = ? WHERE id = ?', [$hash, $id]);
         return $stmt !== false;
     }
 }


### PR DESCRIPTION
## Summary
- add stylish toggle with sun/moon icons for dark mode
- include last_login column and record on login
- show last login in Users table
- add page to change password
- add Admin > Linhas de Produto management
- update README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686810a8d3a8832bb953b9f66845b392